### PR TITLE
fix: throw error when init non-legit SubAccount

### DIFF
--- a/src/BitSubAccount.ts
+++ b/src/BitSubAccount.ts
@@ -18,7 +18,7 @@ export class BitSubAccount extends BitAccount {
   constructor (options: BitAccountOptions) {
     super(options)
     if (!isSubAccount(options.account)) {
-      throw new DotbitError(`${options.account} is not a legit SubDID`, BitErrorCode.InvalidAccountId)
+      throw new DotbitError(`${options.account} is not a legit SubDID`, BitErrorCode.InvalidSubAccount)
     }
     this.mainAccount = this.account.replace(/^.+?\./, '')
   }

--- a/src/BitSubAccount.ts
+++ b/src/BitSubAccount.ts
@@ -9,6 +9,7 @@ import {
   TxsSignedOrUnSigned
 } from './fetchers/SubAccountAPI'
 import { BitErrorCode, DotbitError } from './errors/DotbitError'
+import { isSubAccount } from './tools/account'
 
 export class BitSubAccount extends BitAccount {
   isSubAccount = true
@@ -16,6 +17,9 @@ export class BitSubAccount extends BitAccount {
 
   constructor (options: BitAccountOptions) {
     super(options)
+    if (!isSubAccount(options.account)) {
+      throw new DotbitError(`${options.account} is not a legit SubDID`, BitErrorCode.InvalidAccountId)
+    }
     this.mainAccount = this.account.replace(/^.+?\./, '')
   }
 

--- a/src/errors/DotbitError.ts
+++ b/src/errors/DotbitError.ts
@@ -28,6 +28,7 @@ export enum BitErrorCode {
   SignerRequired,
   BitBuilderRequired,
   InvalidAccountId,
+  InvalidSubAccount,
 }
 
 export class DotbitError extends Error {

--- a/src/tools/account.ts
+++ b/src/tools/account.ts
@@ -87,11 +87,13 @@ export function toRecordExtended (record: BitAccountRecord): BitAccountRecordExt
 
 /**
  * Check if a given account is SubDID.
- * 001.imac.bit vs imac.bit
+ * Multi-level SubDID is supported.
+ * e.g. 111.imac.bit / 222.333.imac.bit
  * @param account
  */
 export function isSubAccount (account: string): boolean {
-  return account.split('.').length >= 3
+  const subAccountPattern = /^([^\.\s]+\.){2,}bit$/
+  return subAccountPattern.test(account)
 }
 
 /**

--- a/tests/BitSubAccount.test.ts
+++ b/tests/BitSubAccount.test.ts
@@ -1,23 +1,17 @@
 import { CoinType } from '../src/const'
-import { subAccountWithSigner, bitIndexer, bitBuilder, signer } from './common/index'
+import { subAccountWithSigner } from './common/index'
 import { BitSubAccount } from '../src/BitSubAccount'
 
 describe('constructor', function () {
   it('should NOT throw error when pass a legit SubDID', () => {
     return expect(() => new BitSubAccount({
       account: 'what.imac.bit',
-      bitIndexer,
-      bitBuilder,
-      signer
     })).not.toThrowError()
   })
   it('should throw error when pass a non-legit SubDID', () => {
     return expect(() => new BitSubAccount({
       account: 'imac.bit',
-      bitIndexer,
-      bitBuilder,
-      signer
-    })).toThrow('1005: imac.bit is not a legit SubDID')
+    })).toThrow('1006: imac.bit is not a legit SubDID')
   })
 })
 

--- a/tests/BitSubAccount.test.ts
+++ b/tests/BitSubAccount.test.ts
@@ -1,5 +1,25 @@
 import { CoinType } from '../src/const'
-import { subAccountWithSigner } from './common/index'
+import { subAccountWithSigner, bitIndexer, bitBuilder, signer } from './common/index'
+import { BitSubAccount } from '../src/BitSubAccount'
+
+describe('constructor', function () {
+  it('should NOT throw error when pass a legit SubDID', () => {
+    return expect(() => new BitSubAccount({
+      account: 'what.imac.bit',
+      bitIndexer,
+      bitBuilder,
+      signer
+    })).not.toThrowError()
+  })
+  it('should throw error when pass a non-legit SubDID', () => {
+    return expect(() => new BitSubAccount({
+      account: 'imac.bit',
+      bitIndexer,
+      bitBuilder,
+      signer
+    })).toThrow('1005: imac.bit is not a legit SubDID')
+  })
+})
 
 describe('enableSubAccount', function () {
   it('throw error', function () {

--- a/tests/common/index.ts
+++ b/tests/common/index.ts
@@ -3,12 +3,12 @@ import { BitAccount } from '../../src/BitAccount'
 import { BitSubAccount } from '../../src/BitSubAccount'
 import { BitIndexer, DotBit, EthersSigner, RemoteTxBuilder } from '../../src/index'
 
-export const bitIndexer = new BitIndexer({
+const bitIndexer = new BitIndexer({
   // uri: 'https://indexer-v1.did.id',
   uri: 'https://test-indexer.did.id',
   // uri: 'https://test-indexer-not-use-in-production-env.did.id',
 })
-export const bitBuilder = new RemoteTxBuilder({
+const bitBuilder = new RemoteTxBuilder({
   subAccountUri: 'https://test-subaccount-api.did.id/v1',
   registerUri: 'https://test-register-api.did.id/v1',
 })
@@ -16,7 +16,7 @@ const address = '0x7df93d9F500fD5A9537FEE086322a988D4fDCC38'
 const privateKey1 = '87d8a2bccdfc9984295748fa2058136c8131335f59930933e9d4b3e74d4fca42'
 const provider = new ethers.providers.InfuraProvider('goerli')
 const wallet = new Wallet(privateKey1, provider)
-export const signer = new EthersSigner(wallet)
+const signer = new EthersSigner(wallet)
 
 const bitIndexerProd = new BitIndexer({
   uri: 'https://indexer-v1.did.id',

--- a/tests/common/index.ts
+++ b/tests/common/index.ts
@@ -3,12 +3,12 @@ import { BitAccount } from '../../src/BitAccount'
 import { BitSubAccount } from '../../src/BitSubAccount'
 import { BitIndexer, DotBit, EthersSigner, RemoteTxBuilder } from '../../src/index'
 
-const bitIndexer = new BitIndexer({
+export const bitIndexer = new BitIndexer({
   // uri: 'https://indexer-v1.did.id',
   uri: 'https://test-indexer.did.id',
   // uri: 'https://test-indexer-not-use-in-production-env.did.id',
 })
-const bitBuilder = new RemoteTxBuilder({
+export const bitBuilder = new RemoteTxBuilder({
   subAccountUri: 'https://test-subaccount-api.did.id/v1',
   registerUri: 'https://test-register-api.did.id/v1',
 })
@@ -16,7 +16,7 @@ const address = '0x7df93d9F500fD5A9537FEE086322a988D4fDCC38'
 const privateKey1 = '87d8a2bccdfc9984295748fa2058136c8131335f59930933e9d4b3e74d4fca42'
 const provider = new ethers.providers.InfuraProvider('goerli')
 const wallet = new Wallet(privateKey1, provider)
-const signer = new EthersSigner(wallet)
+export const signer = new EthersSigner(wallet)
 
 const bitIndexerProd = new BitIndexer({
   uri: 'https://indexer-v1.did.id',

--- a/tests/tools/account.test.ts
+++ b/tests/tools/account.test.ts
@@ -114,17 +114,31 @@ describe('accountIdHex', function () {
 })
 
 describe('isSubAccount', function () {
-  it('should be false for main-account', function () {
-    expect(isSubAccount('imac.bit')).toBe(false)
-  })
-
-  it('should be true for SubDID', function () {
-    expect(isSubAccount('superdid.2077.bit')).toBe(true)
-  })
-
-  it('should be false for hash-style account', function () {
-    expect(isSubAccount('imac#001.bit')).toBe(false)
-  })
+  it.each`
+  account  | expected
+  ${'imac.bit'}  | ${false}
+  ${'superdid.2077.bit'} | ${true}
+  ${'imac#001.bit'}  | ${false}
+  ${'test.third.level.bit'} | ${true}
+  ${'just.test.fourth.level.bit'} | ${true}
+  ${'🐶.quốcngữ.😊.bit'} | ${true}
+  ${'.third.level.bit'} | ${false}
+  ${'superdid..2077.bit'} | ${false}
+  ${'superdid.2077..bit'} | ${false}
+  ${'empty space.にほんご.bit'} | ${false}
+  ${'hello. a.bit'} | ${false}
+  ${' .check.bit'} | ${false}
+  ${'recheck.check. bit'} | ${false}
+  ${'にほんご🐶.bit'} | ${false}
+  ${'.....bit'} | ${false}
+  ${'non-empty-space.にほんご.bit'} | ${true}
+`(
+    'should return $expected when account is $account',
+    ({ account, expected }) => {
+      const result = isSubAccount(account)
+      expect(result).toBe(expected)
+    },
+  )
 })
 
 describe('getAccountCharsetTypes', function () {


### PR DESCRIPTION
# What's New
- To add a regex for validating SubDID (supporting multi-level)
- To throw an error when creating SubAccount instance with a non-legit SubDID
- Add unit test cases for the changes above.