### PR TITLE
fix: account suffix validation bug

### DIFF
--- a/src/tools/account.ts
+++ b/src/tools/account.ts
@@ -13,10 +13,10 @@ import { ACCOUNT_SUFFIX, CHAR_TYPE, languageToCharType, languages, DigitalEmojiU
 
 /**
  * @description: check if the account is supported by .bit
- * @param account in the format of `xxx.bit`
+ * @param account in the format of `[xxx.]xxx.bit`
  */
 export function isSupportedAccount (account: string): boolean {
-  return /.+\.bit/.test(account) && account.split(/.#/).every(v => Boolean(v.length))
+  return /^([^\.\s]+\.){1,}bit$/.test(account) && account.split(/.#/).every(v => Boolean(v.length))
 }
 
 /**

--- a/tests/tools/account.test.ts
+++ b/tests/tools/account.test.ts
@@ -16,10 +16,22 @@ describe('isSupportedAccount', function () {
     expect(isSupported).toBe(true)
   })
 
+  it('do not support abc.bitbit', async () => {
+    const isSupported = isSupportedAccount('abc.bitbit')
+
+    expect(isSupported).toBe(false)
+  })
+
   it('SubDID', function () {
     const isSupported = isSupportedAccount('a.phone.bit')
 
     expect(isSupported).toBe(true)
+  })
+
+  it('do not support abc....phone.bit', function () {
+    const isSupported = isSupportedAccount('abc....phone.bit')
+
+    expect(isSupported).toBe(false)
   })
 
   it('emoji', function () {


### PR DESCRIPTION
1. `abc.bitttt` will be matched.
2. `abc...abc.bit` will be matched.