### PR TITLE
feat: add accountsOfManager.

### DIFF
--- a/docs/api/dotbit.md
+++ b/docs/api/dotbit.md
@@ -13,6 +13,7 @@
 - [reverse(keyInfo)](#reversekeyinfo)
 - [alias](#alias)
 - [accountsOfOwner(keyInfo)](#accountsofownerkeyinfo)
+- [accountsOfManager(keyInfo)](#accountsofmanagerkeyinfo)
 - [account(account)](#accountaccount)
 - [exist(account)](#existaccount)
 - [accountById(accountId)](#accountbyidaccountid)
@@ -268,7 +269,7 @@ BitAccount {
 The API is the same as [reverse(keyInfo)](#reversekeyinfo).
 
 ## accountsOfOwner(keyInfo)
-List all .bit accounts (including SubDID accounts) of a given blockchain address
+List all .bit accounts (including SubDID accounts) of a given blockchain owner address
 ### Parameters
 - keyInfo: `KeyInfo`
   - key: `string`. The address on a certain blockchain
@@ -279,6 +280,43 @@ Promise<BitAccount[]>
 ```javascript
 // To get all BitAccount instances of Ethereum addresss '0x1d643fac9a463c9d544506006a6348c234da485f'
 dotbit.accountsOfOwner({
+  key: "0x1d643fac9a463c9d544506006a6348c234da485f",
+  coin_type: "60" // The coin type of ETH
+}).then(console.log);
+
+// ...
+// The printed result would be like:
+[
+  ...,
+  BitAccount {
+    account: 'cz-vs-sbf.bit',
+    bitIndexer: BitIndexer { rpc: [JSONRPC] },
+    bitBuilder: RemoteTxBuilder {},
+    signer: // Your signer instance
+  },
+  BitSubAccount {
+    account: 'jeff.makeafriend.bit',
+    bitIndexer: BitIndexer { rpc: [JSONRPC] },
+    bitBuilder: RemoteTxBuilder {},
+    signer: // Your signer instance
+    isSubAccount: true,
+    mainAccount: 'makeafriend.bit'
+  }
+]
+```
+
+## accountsOfManager(keyInfo)
+List all .bit accounts (including SubDID accounts) of a given blockchain manager address
+### Parameters
+- keyInfo: `KeyInfo`
+  - key: `string`. The address on a certain blockchain
+  - (Optional) coin_type: `string`. (60: ETH, 195: TRX, 714: BNB, 966: Matic). See [What is coin_type?](../../README.md#what-is-coin_type) in FAQ for more details.
+### Return Value
+Promise<BitAccount[]>
+### Example
+```javascript
+// To get all BitAccount instances of Ethereum addresss '0x1d643fac9a463c9d544506006a6348c234da485f'
+dotbit.accountsOfManager({
   key: "0x1d643fac9a463c9d544506006a6348c234da485f",
   coin_type: "60" // The coin type of ETH
 }).then(console.log);

--- a/src/DotBit.ts
+++ b/src/DotBit.ts
@@ -106,6 +106,12 @@ export class DotBit {
     return accounts.map(account => this.getAccount(account))
   }
 
+  async accountsOfManager (keyInfo: KeyInfo): Promise<BitAccount[]> {
+    const accounts =  await this.bitIndexer.accountList(keyInfo, 'manager')
+
+    return accounts.map(account => this.getAccount(account))
+  }
+
   account (account: string): BitAccount {
     return this.getAccount(account)
   }

--- a/src/fetchers/BitIndexer.ts
+++ b/src/fetchers/BitIndexer.ts
@@ -64,11 +64,11 @@ export class BitIndexer {
    * @param keyInfo
    * @param role
    */
-  accountList (keyInfo: KeyInfo, role?: 'manager'|'owner'): Promise<string[]> {
+  accountList (keyInfo: KeyInfo, role: 'manager' | 'owner' = 'owner'): Promise<string[]> {
     return this.request<BitAccountList>('das_accountList', [{
       type: 'blockchain',
       key_info: keyInfo,
-      role: role || 'owner',
+      role,
     }])
       .then(result => result.account_list.map(item => item.account))
   }

--- a/src/fetchers/BitIndexer.ts
+++ b/src/fetchers/BitIndexer.ts
@@ -62,11 +62,13 @@ export class BitIndexer {
   /**
    * Get all accounts whose owner is given key.
    * @param keyInfo
+   * @param role
    */
-  accountList (keyInfo: KeyInfo): Promise<string[]> {
+  accountList (keyInfo: KeyInfo, role?: 'manager'|'owner'): Promise<string[]> {
     return this.request<BitAccountList>('das_accountList', [{
       type: 'blockchain',
       key_info: keyInfo,
+      role: role || 'owner',
     }])
       .then(result => result.account_list.map(item => item.account))
   }

--- a/tests/DotBit.test.ts
+++ b/tests/DotBit.test.ts
@@ -49,6 +49,18 @@ describe('accountsOfOwner', function () {
   })
 })
 
+describe('accountsOfManager', function () {
+  it('work', async function () {
+    const accounts = await dotbitProd.accountsOfManager({
+      key: '0x1d643fac9a463c9d544506006a6348c234da485f',
+      coin_type: CoinType.ETH,
+    })
+
+    expect(accounts[0]).toBeInstanceOf(BitAccount)
+    expect(accounts.length).toBeGreaterThan(10)
+  })
+})
+
 describe('accountById', function () {
   it('work', async function () {
     const account = await dotbitProd.accountById('0x5728088435fb8788472a9ca601fbc0b9cbea8be3')

--- a/tests/fetchers/BitIndexer.test.ts
+++ b/tests/fetchers/BitIndexer.test.ts
@@ -137,6 +137,6 @@ describe('accountList', () => {
       coin_type: CoinType.ETH, // 60: ETH, 195: TRX, 714: BNB, 966: Matic
       key: '0x1D643FAc9a463c9d544506006a6348c234dA485f' // address
     }, 'manager')
-    expect(accounts.length).toBeGreaterThanOrEqual(22)
+    expect(accounts.length).toBeGreaterThanOrEqual(10)
   })
 })

--- a/tests/fetchers/BitIndexer.test.ts
+++ b/tests/fetchers/BitIndexer.test.ts
@@ -131,4 +131,12 @@ describe('accountList', () => {
     })
     expect(accounts.length).toBe(0)
   })
+
+  it('work when the role is "manager"', async () => {
+    const accounts = await indexer.accountList({
+      coin_type: CoinType.ETH, // 60: ETH, 195: TRX, 714: BNB, 966: Matic
+      key: '0x1D643FAc9a463c9d544506006a6348c234dA485f' // address
+    }, 'manager')
+    expect(accounts.length).toBeGreaterThanOrEqual(22)
+  })
 })


### PR DESCRIPTION
List all .bit accounts (including SubDID accounts) of a given blockchain manager address.